### PR TITLE
Support for MySQL databases

### DIFF
--- a/ajax/config.php
+++ b/ajax/config.php
@@ -20,9 +20,15 @@
 
 $res = array('status' => 'ok');
 
-$DB_PATH = '/var/www/sqlite';
 $DB_PERSISTENT = true;
-$DB_NAME = "$DB_PATH/ctSESAM-server.sqlite";
+#$DB_PATH = '/var/www/sqlite';
+#$DB_NAME = "$DB_PATH/ctSESAM-server.sqlite";
+$DB_HOST = 'localhost';
+$DB_NAME = 'sesam';
+$DB_USER = 'sesam';
+$DB_PASSWD = 'sesam';
+#$DB_CONN = "sqlite:$DB_NAME";
+$DB_CONN = 'mysql:host='.$DB_HOST.';dbname='.$DB_NAME;
 
 function directCall() {
   return substr(str_replace("\\", '/', __FILE__), -strlen($_SERVER['PHP_SELF'])) === $_SERVER['PHP_SELF'];
@@ -33,3 +39,4 @@ if (directCall()) {
   $res['message'] = "Calling " . $_SERVER['PHP_SELF'] . " directly doesn't do anything ;-)";
   echo json_encode($res);
 }
+?>

--- a/ajax/globals.php
+++ b/ajax/globals.php
@@ -56,10 +56,10 @@ function processingTime() {
   return ($dt < 0.001) ? '<1ms' : '~' . $dt . 's';
 }
 
-$dbh = new PDO("sqlite:$DB_NAME", null, null,
+$dbh = new PDO($DB_CONN, $DB_USER, $DB_PASSWD,
 	       array(
 		     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
 		     PDO::ATTR_PERSISTENT => $DB_PERSISTENT
 		     )
 	       );
-
+?>

--- a/ajax/install.php
+++ b/ajax/install.php
@@ -3,13 +3,13 @@ require_once 'globals.php';
 
 header('Content-type: text/plain');
 if ($dbh) {
-    $dbh->exec('CREATE TABLE IF NOT EXISTS `domains` (' .
-        ' `userid` TEXT PRIMARY KEY,' .
-        ' `data` BLOB' .
+    $dbh->exec('CREATE TABLE IF NOT EXISTS domains (' .
+        ' userid VARCHAR(255) PRIMARY KEY,' .
+        ' data BLOB' .
         ')');
     echo "Table 'domains' created.";
 }
 else {
   echo "Something went wrong.";
 }
-
+?>


### PR DESCRIPTION
I have made some changes and have proposed some suggestions on how to enable the user to choose between different database systems:

Defining some more variables in config.php and making appropriate adjustments to the parameters in the creation of the PDO object in globals.php would restrict configuration settings to config.php.

Since MySQL databases do not allow indexing TEXT datatypes I suggest to change the datatype of the primary key column to VARCHAR(255). This should work on SQLite3 databases as well (I have not tested it, though).
